### PR TITLE
feat: 로그인/로그아웃 시 세션 정보 저장

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 카카오 로그인
 - 폰트 Pretandard 적용
+- 로그인 정보를 UserDefaults와 Keychain에 저장
 
 [unreleased]: https://github.com/Picplz/picplz-ios

--- a/PicplzClient/PicplzClient/App/AppCoordinator.swift
+++ b/PicplzClient/PicplzClient/App/AppCoordinator.swift
@@ -13,13 +13,17 @@ final class AppCoordinator: Coordinator {
     private let window: UIWindow
     private let navigationController: UINavigationController
     private var isLoggedIn = false
+    private let container: Container
     private let log = Logger.of("AppCoordinator")
     
     init?(window: UIWindow?) {
+    init?(window: UIWindow?, container: Container) {
         guard let window = window else { return nil }
         
         self.window = window
         navigationController = UINavigationController()
+        
+        self.container = container
     }
     
     deinit {

--- a/PicplzClient/PicplzClient/App/AppCoordinator.swift
+++ b/PicplzClient/PicplzClient/App/AppCoordinator.swift
@@ -7,16 +7,16 @@
 
 import UIKit
 import OSLog
+import Swinject
 
 final class AppCoordinator: Coordinator {
     var childCoordinators: [any Coordinator] = []
     private let window: UIWindow
     private let navigationController: UINavigationController
-    private var isLoggedIn = false
     private let container: Container
+    private let authManaging: AuthManaging
     private let log = Logger.of("AppCoordinator")
     
-    init?(window: UIWindow?) {
     init?(window: UIWindow?, container: Container) {
         guard let window = window else { return nil }
         
@@ -24,6 +24,13 @@ final class AppCoordinator: Coordinator {
         navigationController = UINavigationController()
         
         self.container = container
+        
+        if let authManaging = container.resolve(AuthManaging.self) {
+            self.authManaging = authManaging
+        } else {
+            log.error("AuthManaging could not be resolved...")
+            preconditionFailure("AuthManaging could not be resolved...")
+        }
     }
     
     deinit {
@@ -31,7 +38,7 @@ final class AppCoordinator: Coordinator {
     }
     
     func start() {
-        if !isLoggedIn {
+        if !authManaging.isLogin {
             showLogin()
         } else {
             showMain()
@@ -44,14 +51,14 @@ final class AppCoordinator: Coordinator {
     }
     
     func showLogin() {
-        let coordinator = LoginCoordinator(navigationController: navigationController)
+        let coordinator = LoginCoordinator(navigationController: navigationController, container: container)
         childCoordinators.append(coordinator)
         coordinator.delegate = self
         coordinator.start()
     }
     
     func showMain() {
-        let coordinator = MainCoordinator(navigationController: navigationController)
+        let coordinator = MainCoordinator(navigationController: navigationController, container: container)
         childCoordinators.append(coordinator)
         coordinator.delegate = self
         coordinator.start()

--- a/PicplzClient/PicplzClient/App/DIContainerProvider.swift
+++ b/PicplzClient/PicplzClient/App/DIContainerProvider.swift
@@ -24,7 +24,7 @@ final class DIContainerProvider {
         
         // MARK: Data
         container.register(AuthManaging.self) { _ in
-            AuthManager()
+            AuthManager(keychainStore: KeychainStore(), userDefaultHelper: UserDefaultsHelper())
         }
         .inObjectScope(.container)
         

--- a/PicplzClient/PicplzClient/App/SceneDelegate.swift
+++ b/PicplzClient/PicplzClient/App/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.windowScene = windowScene
-        coordinator = AppCoordinator(window: window)
+        coordinator = AppCoordinator(window: window, container: DIContainerProvider.shared.container)
         coordinator?.start()
     }
 

--- a/PicplzClient/PicplzClient/Data/Auth/AuthManager.swift
+++ b/PicplzClient/PicplzClient/Data/Auth/AuthManager.swift
@@ -8,10 +8,22 @@
 import Foundation
 import OSLog
 
-final class AuthManager: AuthManaging {    
+final class AuthManager: AuthManaging {
+    // MARK: Dependencies
+    private let keychainStore: KeychainStore
+    private let userDefaultHelper: UserDefaultsHelper
+    
+    // MARK: Properties
     private var accessTokenModel: AccessToken?
     private var currentUserModel: AuthUserModel?
+    
     private var log = Logger.of("AuthManager")
+    
+    init(keychainStore: KeychainStore, userDefaultHelper: UserDefaultsHelper) {
+        self.keychainStore = keychainStore
+        self.userDefaultHelper = userDefaultHelper
+        loadFromDeviceStore()
+    }
     
     var accessToken: String? {
         guard let accessTokenModel = accessTokenModel else { return nil }
@@ -32,30 +44,87 @@ final class AuthManager: AuthManaging {
     func login(accessToken: String, expiresDate: Date, user currentUserEntity: AuthUser) {
         self.accessTokenModel = AccessToken(token: accessToken, expiresDate: expiresDate)
         self.currentUserModel = AuthUserModel.from(entity: currentUserEntity)
+        setToDeviceStore()
         
-        log.info("AuthManager login... token=\(String(describing: self.accessTokenModel)) currentUser=\(String(describing: self.currentUserModel))")
+        log.debug("AuthManager login... token=\(String(describing: self.accessTokenModel)) currentUser=\(String(describing: self.currentUserModel))")
     }
     
     func logout() {
-        log.info("AuthManager logout...")
+        log.debug("AuthManager logout...")
         reset()
     }
     
     private func reset() {
-        log.info("AuthManager reset...")
+        log.debug("AuthManager reset...")
         accessTokenModel = nil
         currentUserModel = nil
+        setToDeviceStore()
     }
     
     func validateToken() -> Bool {
         guard let expiresDate = accessTokenModel?.expiresDate else { return false }
         
         if Date() > expiresDate {
-            log.info("Token expired... currentDate=\(Date()) expiredDate=\(expiresDate)")
+            log.warning("Token expired... currentDate=\(Date()) expiredDate=\(expiresDate)")
             reset()
             return false
         }
         
         return true
+    }
+    
+    private func setToDeviceStore() {
+        // MARK: save currentUserModel
+        if let currentUserModel = currentUserModel {
+            userDefaultHelper.save(value: currentUserModel, key: .authUser)
+            log.debug("saved currentUserModel to UserDefaults... value=\(String(describing: currentUserModel))")
+        } else {
+            userDefaultHelper.delete(for: .authUser)
+            log.debug("deleted currentUserModel from UserDefaults...")
+        }
+        
+        // MARK: save accessTokenModel
+        if let accessTokenModel = accessTokenModel {
+            userDefaultHelper.save(value: accessTokenModel.expiresDate, key: .accessTokenExpiresAt)
+            log.debug("saved accessTokenModel.expiresDate to UserDefaults... value=\(String(describing: accessTokenModel.expiresDate))")
+            
+            do {
+                try keychainStore.saveValue(accessTokenModel.token, for: KeychainStore.ReservedAccount.AccessToken.rawValue)
+                log.debug("saved accessTokenModel.token to keychain...")
+            } catch {
+                log.error("failed to save accessTokenModel.token to keychain... error: \(error)")
+            }
+        } else {
+            userDefaultHelper.delete(for: .accessTokenExpiresAt)
+            log.debug("deleted accessTokenModel.expiresDate from UserDefaults...")
+            
+            do {
+                try keychainStore.remove(for: KeychainStore.ReservedAccount.AccessToken.rawValue)
+                log.debug("deleted accessTokenModel.token from keychain...")
+            } catch {
+                log.error("failed to delete accessTokenModel.token from keychain... error: \(error)")
+            }
+        }
+    }
+    
+    private func loadFromDeviceStore() {
+        // MARK: load currentUserModel
+        currentUserModel = userDefaultHelper.load(for: .authUser)
+        log.debug("loaded currentUserModel from UserDefaults...")
+        
+        // MARK: load accessTokenModel
+        var accessToken: String?
+        do {
+            try accessToken = keychainStore.loadValue(for: KeychainStore.ReservedAccount.AccessToken.rawValue)
+        } catch {
+            log.error("failed to load accessTokenModel.token from keychain... error: \(error)")
+        }
+        let expiresDate: Date? = userDefaultHelper.load(for: .accessTokenExpiresAt)
+        
+        guard let expiresDate = expiresDate,
+              let accessToken = accessToken else { return }
+        
+        accessTokenModel = AccessToken(token: accessToken, expiresDate: expiresDate)
+        log.debug("loaded accessTokenModel.token from keychain...")
     }
 }

--- a/PicplzClient/PicplzClient/Data/Auth/KeychainStore.swift
+++ b/PicplzClient/PicplzClient/Data/Auth/KeychainStore.swift
@@ -1,0 +1,113 @@
+//
+//  KeychainStore.swift
+//  PicplzClient
+//
+//  Created by 임영택 on 2/14/25.
+//
+
+import Foundation
+import Security
+import OSLog
+
+final class KeychainStore {
+    let queryBase: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: Bundle.main.bundleIdentifier ?? "com.hm.picplz.PicplzClient"
+    ]
+    
+    private let log = Logger.of("KeyChainStore")
+    
+    func saveValue(_ value: String, for account: String) throws {
+        guard let valueAsData = value.data(using: .utf8) else {
+            log.error("failed to encode string to data")
+            throw KeyChainStoreError.failedToEncodeToData
+        }
+        
+        var query = queryBase
+        query[String(kSecAttrAccount)] = account
+        
+        var status = SecItemCopyMatching(query as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            let shouldUpdateAttributes: [String: Any] = [
+                kSecValueData as String: valueAsData
+            ]
+            
+            status = SecItemUpdate(query as CFDictionary, shouldUpdateAttributes as CFDictionary)
+            if status != errSecSuccess {
+                throw getError(from: status)
+            }
+        case errSecItemNotFound:
+            query[String(kSecValueData)] = valueAsData
+            
+            status = SecItemAdd(query as CFDictionary, nil)
+            if status != errSecSuccess {
+                throw getError(from: status)
+            }
+        default:
+            throw getError(from: status)
+        }
+    }
+    
+    func loadValue(for account: String) throws -> String? {
+        var query = queryBase
+        query[String(kSecMatchLimit)] = kSecMatchLimitOne
+        query[String(kSecReturnData)] = kCFBooleanTrue
+        query[String(kSecReturnAttributes)] = kCFBooleanTrue
+        query[String(kSecAttrAccount)] = account
+        
+        var result: AnyObject?
+        let status = withUnsafeMutablePointer(to: &result) {
+          SecItemCopyMatching(query as CFDictionary, $0)
+        }
+        
+        switch status {
+        case errSecSuccess:
+            if let result = result as? [String: Any],
+               let loadedValue = result[String(kSecValueData)] as? Data,
+               let decodedValue = String(data: loadedValue, encoding: .utf8) {
+                return decodedValue
+            } else {
+                throw KeyChainStoreError.failedToDecodeToString
+            }
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw getError(from: status)
+        }
+    }
+    
+    func remove(for account: String) throws {
+        var query = queryBase
+        query[String(kSecAttrAccount)] = account
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw getError(from: status)
+        }
+    }
+    
+    func removeAll() throws {
+        let query = queryBase
+          
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw getError(from: status)
+        }
+    }
+    
+    private func getError(from status: OSStatus) -> KeyChainStoreError {
+        let message = SecCopyErrorMessageString(status, nil) as String? ?? "Unexpected..."
+        return KeyChainStoreError.unknown(message)
+    }
+    
+    enum ReservedAccount: String {
+        case AccessToken
+    }
+    
+    enum KeyChainStoreError: Error {
+        case failedToEncodeToData
+        case failedToDecodeToString
+        case unknown(String)
+    }
+}

--- a/PicplzClient/PicplzClient/Data/Auth/Model/AuthUserModel.swift
+++ b/PicplzClient/PicplzClient/Data/Auth/Model/AuthUserModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct AuthUserModel {
+struct AuthUserModel: Codable {
     let name: String
     let nickname: String
     let birth: Date

--- a/PicplzClient/PicplzClient/Data/Auth/UserDefaultsHelper.swift
+++ b/PicplzClient/PicplzClient/Data/Auth/UserDefaultsHelper.swift
@@ -1,0 +1,119 @@
+//
+//  UserDefaultsHelper.swift
+//  PicplzClient
+//
+//  Created by 임영택 on 2/14/25.
+//
+
+import Foundation
+import OSLog
+
+final class UserDefaultsHelper {
+    private let userDefaults: UserDefaults
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let log = Logger.of("UserDefaultsHelper")
+    
+    init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+        encoder = JSONEncoder()
+        decoder = JSONDecoder()
+    }
+    
+    convenience init() {
+        self.init(userDefaults: UserDefaults.standard)
+    }
+    
+    private func saveCustomObject<T: Encodable>(_ object: T, key: Key) {
+        do {
+            let jsonData = try encoder.encode(object)
+            userDefaults.set(jsonData, forKey: key.rawValue)
+        } catch {
+            log.error("Encode data failed... key: \(key.rawValue) value: \(String(describing: object)) error: \(error)")
+        }
+    }
+    
+    private func loadCustomData<T: Decodable>(for key: Key, as type: T.Type) -> T? {
+        guard let jsonData = userDefaults.data(forKey: key.rawValue) else {
+            log.error("No data from UserDefaults... key: \(key.rawValue)")
+            return nil
+        }
+        
+        do {
+            let object = try decoder.decode(T.self, from: jsonData)
+            return object
+        } catch {
+            log.error("Decode data failed... key: \(key.rawValue) error: \(error)")
+            return nil
+        }
+    }
+    
+    func save(value: Any, key: Key) {
+        let keyRaw = key.rawValue
+        let expectedType = key.expectedType
+        
+        switch expectedType {
+        case is String.Type:
+            fallthrough
+        case is Int.Type:
+            fallthrough
+        case is Double.Type:
+            fallthrough
+        case is Bool.Type:
+            fallthrough
+        case is Data.Type:
+            userDefaults.set(value, forKey: key.rawValue)
+        case is Codable.Type:
+            if let value = value as? Codable {
+                saveCustomObject(value, key: key)
+            }
+        default:
+            userDefaults.set(value, forKey: keyRaw)
+        }
+    }
+    
+    func load<T>(for key: Key) -> T? {
+        let expectedType = key.expectedType
+        
+        switch expectedType {
+        case is String.Type:
+            log.info("String")
+            return userDefaults.string(forKey: key.rawValue) as? T
+        case is Int.Type:
+            return userDefaults.integer(forKey: key.rawValue) as? T
+        case is Double.Type:
+            return userDefaults.double(forKey: key.rawValue) as? T
+        case is Bool.Type:
+            return userDefaults.bool(forKey: key.rawValue) as? T
+        case is Data.Type:
+            return userDefaults.data(forKey: key.rawValue) as? T
+        case is Codable.Type:
+            if let expectedType = expectedType as? Decodable.Type {
+                return loadCustomData(for: key, as: expectedType) as? T
+            }
+        default:
+            log.error("Unsupported type \(expectedType) for key \(key.rawValue)")
+            return nil
+        }
+        
+        return nil
+    }
+    
+    struct Key: RawRepresentable {
+        let rawValue: String
+        let expectedType: Any.Type
+        
+        init?(rawValue: String) {
+            self.rawValue = rawValue
+            self.expectedType = Any.self
+        }
+        
+        init(rawValue: String, expectedType: Any.Type) {
+            self.rawValue = rawValue
+            self.expectedType = expectedType
+        }
+        
+        static let accessTokenExpiresAt = Key(rawValue: "accessTokenExpiresAt", expectedType: String.self)
+        static let authUser = Key(rawValue: "authUser", expectedType: AuthUser.self)
+    }
+}

--- a/PicplzClient/PicplzClient/Data/Auth/UserDefaultsHelper.swift
+++ b/PicplzClient/PicplzClient/Data/Auth/UserDefaultsHelper.swift
@@ -99,6 +99,10 @@ final class UserDefaultsHelper {
         return nil
     }
     
+    func delete(for key: Key) {
+        userDefaults.removeObject(forKey: key.rawValue)
+    }
+    
     struct Key: RawRepresentable {
         let rawValue: String
         let expectedType: Any.Type

--- a/PicplzClient/PicplzClient/Data/Auth/UserDefaultsHelper.swift
+++ b/PicplzClient/PicplzClient/Data/Auth/UserDefaultsHelper.swift
@@ -117,7 +117,7 @@ final class UserDefaultsHelper {
             self.expectedType = expectedType
         }
         
-        static let accessTokenExpiresAt = Key(rawValue: "accessTokenExpiresAt", expectedType: String.self)
-        static let authUser = Key(rawValue: "authUser", expectedType: AuthUser.self)
+        static let accessTokenExpiresAt = Key(rawValue: "accessTokenExpiresAt", expectedType: Date.self)
+        static let authUser = Key(rawValue: "authUser", expectedType: AuthUserModel.self)
     }
 }

--- a/PicplzClient/PicplzClient/Presentation/Login/Coordinator/LoginCoordinator.swift
+++ b/PicplzClient/PicplzClient/Presentation/Login/Coordinator/LoginCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import OSLog
+import Swinject
 
 protocol LoginCoordinatorDelegate: AnyObject {
     func finished(loginCoordinator: LoginCoordinator)
@@ -16,11 +17,12 @@ final class LoginCoordinator: Coordinator {
     var childCoordinators: [any Coordinator] = []
     weak var delegate: LoginCoordinatorDelegate?
     private let navigationController: UINavigationController
+    private let container: Container
     private var log = Logger.of("LoginCoordinator")
-    private let container = DIContainerProvider.shared.container
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, container: Container) {
         self.navigationController = navigationController
+        self.container = container
     }
     
     deinit {

--- a/PicplzClient/PicplzClient/Presentation/Main/Coordinator/MainCoordinator.swift
+++ b/PicplzClient/PicplzClient/Presentation/Main/Coordinator/MainCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import OSLog
+import Swinject
 
 protocol MainCoordinatorDelegate: AnyObject {
     func finished(mainCoordinator: MainCoordinator)
@@ -16,11 +17,12 @@ final class MainCoordinator: Coordinator {
     var childCoordinators: [any Coordinator] = []
     weak var delegate: MainCoordinatorDelegate?
     private let navigationController: UINavigationController
+    private let container: Container
     private var log = Logger.of("MainCoordinator")
-    private let container = DIContainerProvider.shared.container
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, container: Container) {
         self.navigationController = navigationController
+        self.container = container
     }
     
     deinit {

--- a/PicplzClient/PicplzClientTests/Data/AuthManagerTests.swift
+++ b/PicplzClient/PicplzClientTests/Data/AuthManagerTests.swift
@@ -15,7 +15,8 @@ struct AuthManagerTests {
     let dummyUser: AuthUser = .init(name: "테스터", nickname: "테스트 닉네임", birth: Date(), role: "GENERAL", kakaoEmail: "test@kakao.co.kr", profileImageUrl: "http://picplz.com/profile.jpg")
     
     init() {
-        authManager = AuthManager()
+        authManager = AuthManager(keychainStore: KeychainStore(),
+                                  userDefaultHelper: UserDefaultsHelper(userDefaults: UserDefaults())) // UserDefaults 분리
     }
     
     let dummyDate: Date = {

--- a/PicplzClient/PicplzClientTests/Data/KeychainStoreTests.swift
+++ b/PicplzClient/PicplzClientTests/Data/KeychainStoreTests.swift
@@ -1,0 +1,144 @@
+//
+//  KeychainStoreTests.swift
+//  PicplzClientTests
+//
+//  Created by 임영택 on 2/14/25.
+//
+
+import Testing
+import Foundation
+import Security
+@testable import PicplzClient
+
+struct KeychainStoreTests {
+    let store: KeychainStore
+    
+    init() {
+        store = KeychainStore()
+    }
+    
+    let accountForTest = "accountForTest-" + UUID().uuidString
+    let secretForTest = "secret#1234@"
+    
+    @Test("아이템 저장에 성공해야 한다.")
+    func addNewItem() async throws {
+        try store.saveValue(secretForTest, for: accountForTest)
+        
+        var query = store.queryBase
+        query[String(kSecAttrAccount)] = accountForTest
+        
+        // MARK: Validate
+        query[String(kSecMatchLimit)] = kSecMatchLimitOne
+        query[String(kSecReturnData)] = kCFBooleanTrue
+        query[String(kSecReturnAttributes)] = kCFBooleanTrue
+        var result: AnyObject?
+        let status = withUnsafeMutablePointer(to: &result) {
+          SecItemCopyMatching(query as CFDictionary, $0)
+        }
+        
+        if status != errSecSuccess {
+            throw NSError(domain: "조회 에러", code: 0)
+        }
+        
+        guard let result = result as? [String: Any],
+              let data = result[String(kSecValueData)] as? Data,
+              let decoded = String(data: data, encoding: .utf8) else {
+            throw NSError(domain: "디코딩 에러", code: 0)
+        }
+        
+        #expect(decoded == secretForTest)
+    }
+    
+    @Test("아이템 수정에 성공해야 한다.")
+    func updateItem() async throws {
+        try store.saveValue(secretForTest, for: accountForTest)
+        try store.saveValue(secretForTest + "%%updated!!", for: accountForTest) // try twice
+        
+        var query = store.queryBase
+        query[String(kSecAttrAccount)] = accountForTest
+        
+        // MARK: Validate
+        query[String(kSecMatchLimit)] = kSecMatchLimitOne
+        query[String(kSecReturnData)] = kCFBooleanTrue
+        query[String(kSecReturnAttributes)] = kCFBooleanTrue
+        var result: AnyObject?
+        let status = withUnsafeMutablePointer(to: &result) {
+          SecItemCopyMatching(query as CFDictionary, $0)
+        }
+        
+        if status != errSecSuccess {
+            throw NSError(domain: "조회 에러", code: 0)
+        }
+        
+        guard let result = result as? [String: Any],
+              let data = result[String(kSecValueData)] as? Data,
+              let decoded = String(data: data, encoding: .utf8) else {
+            throw NSError(domain: "디코딩 에러", code: 0)
+        }
+        
+        #expect(decoded == secretForTest + "%%updated!!")
+    }
+    
+    @Test("아이템 삭제에 성공해야 한다.")
+    func deleteItem() async throws {
+        // MARK: Set Test Pre Condition
+        guard let data = secretForTest.data(using: .utf8) else {
+            throw NSError(domain: "인코딩 실패", code: 0)
+        }
+        var query = store.queryBase
+        query[String(kSecAttrAccount)] = accountForTest
+        query[String(kSecValueData)] = data
+        
+        var status = SecItemAdd(query as CFDictionary, nil)
+        if status != errSecSuccess {
+            throw NSError(domain: "저장 실패", code: 0)
+        }
+        
+        // MARK: Do Test
+        try store.remove(for: accountForTest)
+        
+        // MARK: Validate
+        var queryForValidate = store.queryBase
+        queryForValidate[String(kSecAttrAccount)] = accountForTest
+        status = SecItemCopyMatching(query as CFDictionary, nil)
+        
+        #expect(status == errSecItemNotFound)
+    }
+    
+    @Test("모든 아이템 삭제에 성공해야 한다.")
+    func deleteAllItem() async throws {
+        // MARK: Set Test Pre Condition
+        let secrets = [1, 2, 3, 4, 5].map({ number in
+            return secretForTest + String(number)
+        })
+        .map { $0.data(using: .utf8) }
+        .compactMap { $0 }
+        
+        if secrets.count != 5 {
+            throw NSError(domain: "인코딩 실패", code: 0)
+        }
+        
+        try secrets.forEach {
+            var query = store.queryBase
+            query[String(kSecAttrAccount)] = accountForTest + UUID().uuidString
+            query[String(kSecValueData)] = $0
+            
+            let status = SecItemAdd(query as CFDictionary, nil)
+            if status != errSecSuccess {
+                throw NSError(domain: "저장 실패", code: 0)
+            }
+        }
+        
+        // MARK: Do Test
+        try store.removeAll()
+        
+        // MARK: Validate
+        var queryForValidate = store.queryBase
+        queryForValidate[String(kSecMatchLimit)] = kSecMatchLimitAll
+        queryForValidate[String(kSecReturnData)] = kCFBooleanTrue
+        queryForValidate[String(kSecReturnAttributes)] = kCFBooleanTrue
+        
+        let status = SecItemCopyMatching(queryForValidate as CFDictionary, nil)
+        #expect(status == errSecItemNotFound)
+    }
+}

--- a/PicplzClient/PicplzClientTests/Data/UserDefaultsHelperTests.swift
+++ b/PicplzClient/PicplzClientTests/Data/UserDefaultsHelperTests.swift
@@ -20,6 +20,7 @@ extension UserDefaultsHelper.Key {
     static let testLoadDouble = UserDefaultsHelper.Key(rawValue: "testLoadDouble", expectedType: Double.self)
     static let testLoadBool = UserDefaultsHelper.Key(rawValue: "testLoadBool", expectedType: Bool.self)
     static let testLoadStruct = UserDefaultsHelper.Key(rawValue: "testLoadStruct", expectedType: TestCustomStruct.self)
+    static let testDelete = UserDefaultsHelper.Key(rawValue: "testDelete", expectedType: String.self)
 }
 
 struct TestCustomStruct: Codable, Equatable {
@@ -136,5 +137,16 @@ struct UserDefaultsHelperTest {
         let savedObject: TestCustomStruct? = userDefaultsHelper.load(for: .testLoadStruct)
         
         #expect(willSaveValue == savedObject)
+    }
+    
+    @Test("아이템을 잘 삭제해야 한다")
+    func deleteItem() async throws {
+        let willSaveValue = "Hello, World"
+        userDefaultsInstance.set(willSaveValue, forKey: UserDefaultsHelper.Key.testDelete.rawValue)
+        
+        userDefaultsHelper.delete(for: UserDefaultsHelper.Key.testDelete)
+        
+        let loaded = userDefaultsInstance.string(forKey: UserDefaultsHelper.Key.testDelete.rawValue)
+        #expect(loaded == nil)
     }
 }

--- a/PicplzClient/PicplzClientTests/Data/UserDefaultsHelperTests.swift
+++ b/PicplzClient/PicplzClientTests/Data/UserDefaultsHelperTests.swift
@@ -28,18 +28,12 @@ struct TestCustomStruct: Codable, Equatable {
     let yesOrNot: Bool
 }
 
-final class UserDefaultsHelperTest {
+struct UserDefaultsHelperTest {
     let userDefaultsHelper: UserDefaultsHelper
     let userDefaultsInstance = UserDefaults.standard
     
     init() {
         userDefaultsHelper = UserDefaultsHelper()
-    }
-    
-    deinit {
-        for key in userDefaultsInstance.dictionaryRepresentation().keys {
-            userDefaultsInstance.removeObject(forKey: key.description)
-        }
     }
     
     @Test("문자열을 잘 저장해야한다")

--- a/PicplzClient/PicplzClientTests/Data/UserDefaultsHelperTests.swift
+++ b/PicplzClient/PicplzClientTests/Data/UserDefaultsHelperTests.swift
@@ -1,0 +1,146 @@
+//
+//  UserDefaultsHelper.swift
+//  PicplzClientTests
+//
+//  Created by 임영택 on 2/14/25.
+//
+
+import Testing
+import Foundation
+@testable import PicplzClient
+
+extension UserDefaultsHelper.Key {
+    static let testSaveString = UserDefaultsHelper.Key(rawValue: "testSaveString", expectedType: String.self)
+    static let testSaveInt = UserDefaultsHelper.Key(rawValue: "testSaveInt", expectedType: Int.self)
+    static let testSaveDouble = UserDefaultsHelper.Key(rawValue: "testSaveDouble", expectedType: Double.self)
+    static let testSaveBool = UserDefaultsHelper.Key(rawValue: "testSaveBool", expectedType: Bool.self)
+    static let testSaveStruct = UserDefaultsHelper.Key(rawValue: "testSaveStruct", expectedType: TestCustomStruct.self)
+    static let testLoadString = UserDefaultsHelper.Key(rawValue: "testLoadString", expectedType: String.self)
+    static let testLoadInt = UserDefaultsHelper.Key(rawValue: "testLoadInt", expectedType: Int.self)
+    static let testLoadDouble = UserDefaultsHelper.Key(rawValue: "testLoadDouble", expectedType: Double.self)
+    static let testLoadBool = UserDefaultsHelper.Key(rawValue: "testLoadBool", expectedType: Bool.self)
+    static let testLoadStruct = UserDefaultsHelper.Key(rawValue: "testLoadStruct", expectedType: TestCustomStruct.self)
+}
+
+struct TestCustomStruct: Codable, Equatable {
+    let message: String
+    let number: Int
+    let yesOrNot: Bool
+}
+
+final class UserDefaultsHelperTest {
+    let userDefaultsHelper: UserDefaultsHelper
+    let userDefaultsInstance = UserDefaults.standard
+    
+    init() {
+        userDefaultsHelper = UserDefaultsHelper()
+    }
+    
+    deinit {
+        for key in userDefaultsInstance.dictionaryRepresentation().keys {
+            userDefaultsInstance.removeObject(forKey: key.description)
+        }
+    }
+    
+    @Test("문자열을 잘 저장해야한다")
+    func saveString() async throws {
+        let willSaveValue = "Hello, World"
+        userDefaultsHelper.save(value: willSaveValue, key: .testSaveString)
+        let savedValue = userDefaultsInstance.string(forKey: UserDefaultsHelper.Key.testSaveString.rawValue)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("정수를 잘 저장해야한다")
+    func saveInt() async throws {
+        let willSaveValue = 200
+        userDefaultsHelper.save(value: willSaveValue, key: .testSaveInt)
+        let savedValue = userDefaultsInstance.integer(forKey: UserDefaultsHelper.Key.testSaveInt.rawValue)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("실수를 잘 저장해야한다")
+    func saveDouble() async throws {
+        let willSaveValue = 123.45
+        userDefaultsHelper.save(value: willSaveValue, key: .testSaveDouble)
+        let savedValue = userDefaultsInstance.double(forKey: UserDefaultsHelper.Key.testSaveDouble.rawValue)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("불리언을 잘 저장해야한다")
+    func saveBool() async throws {
+        let willSaveValue = true
+        userDefaultsHelper.save(value: willSaveValue, key: .testSaveBool)
+        let savedValue = userDefaultsInstance.bool(forKey: UserDefaultsHelper.Key.testSaveBool.rawValue)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("커스텀 구조체를 잘 저장해야한다")
+    func saveStruct() async throws {
+        let willSaveValue = TestCustomStruct(message: "Hello World", number: 123, yesOrNot: false)
+        userDefaultsHelper.save(value: willSaveValue, key: .testSaveStruct)
+        
+        let savedValue = userDefaultsInstance.data(forKey: UserDefaultsHelper.Key.testSaveStruct.rawValue)!
+        print(String(decoding: savedValue, as: UTF8.self))
+        
+        let decoder = JSONDecoder()
+        let savedObject = try decoder.decode(TestCustomStruct.self, from: savedValue)
+        
+        #expect(willSaveValue == savedObject)
+    }
+    
+    @Test("문자열을 잘 불러와야 한다")
+    func loadString() async throws {
+        let willSaveValue = "Hello, World"
+        userDefaultsInstance.set(willSaveValue, forKey: UserDefaultsHelper.Key.testLoadString.rawValue)
+        
+        let savedValue: String? = userDefaultsHelper.load(for: .testLoadString)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("정수를 잘 불러와야 한다")
+    func loadInt() async throws {
+        let willSaveValue = 300
+        userDefaultsInstance.set(willSaveValue, forKey: UserDefaultsHelper.Key.testLoadInt.rawValue)
+        
+        let savedValue: Int? = userDefaultsHelper.load(for: .testLoadInt)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("실수를 잘 불러와야 한다")
+    func loadDouble() async throws {
+        let willSaveValue = 678.91
+        userDefaultsInstance.set(willSaveValue, forKey: UserDefaultsHelper.Key.testLoadDouble.rawValue)
+        
+        let savedValue: Double? = userDefaultsHelper.load(for: .testLoadDouble)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("불리언을 잘 불러와야 한다")
+    func loadBool() async throws {
+        let willSaveValue = true
+        userDefaultsInstance.set(willSaveValue, forKey: UserDefaultsHelper.Key.testLoadBool.rawValue)
+        
+        let savedValue: Bool? = userDefaultsHelper.load(for: .testLoadBool)
+        
+        #expect(savedValue == willSaveValue)
+    }
+    
+    @Test("커스텀 구조체를 잘 불러와야 한다")
+    func loadStruct() async throws {
+        let willSaveValue = TestCustomStruct(message: "Bye World", number: 456, yesOrNot: true)
+        let encoder = JSONEncoder()
+        let willSaveJsonData = try encoder.encode(willSaveValue)
+        userDefaultsInstance.set(willSaveJsonData, forKey: UserDefaultsHelper.Key.testLoadStruct.rawValue)
+        
+        let savedObject: TestCustomStruct? = userDefaultsHelper.load(for: .testLoadStruct)
+        
+        #expect(willSaveValue == savedObject)
+    }
+}


### PR DESCRIPTION
## 개요

- 관련 이슈: #4 
- 로그인/로그아웃/토큰 만료 등 여러 시나리오에서 데이터를 영속화할 필요가 있음
- 토큰을 다룰 때에는 키체인, 다른 데이터는 UserDefaults 사용 계획

## 변경점

### UserDefaultsHelper 구현
  - 미리 UserDefaultsHelper.Key에 키와 값의 타입을 정의
  - UserDefaultsHelper.Key는 열거형이 아닌 구조체로 정의해, 테스트 시 키를 확장해 테스트할 수 있게 했음
  - 이후에 키를 추가해야하는 경우 UserDefaultsHelper.Key에 항목을 추가하면 됨.
  - 사용 방법은 테스트코드 참고
  - 앞으로 UserDefaults.standard에 직접 참조하지 말고 UserDefaultsHelper를 통해 참조하도록 주의

### KeychainStore 구현
  - 다음 어트리뷰트를 기본으로 데이터를 저장하는 스토어 구현
    ```swift
    [
        kSecClass as String: kSecClassGenericPassword,
        kSecAttrService as String: Bundle.main.bundleIdentifier ?? "com.hm.picplz.PicplzClient"
    ]
    ```
- 사용 방법은 테스트코드 참고

### AuthManager에 UserDefaultsHelper, KeychainStore 연동
- 저장 방법
  - 엑세스 토큰 자체는 Keychain에 저장
  - 유저 정보, 엑세스 토큰 만료 일시는 UserDefaults에 저장
- setToDeviceStore():
  - UserDefaultsHelper와 KeychainStore를 이용해 세션 정보 저장
  - init에서 호출됨
- loadFromDeviceStore()
  - UserDefaultsHelper와 KeychainStore를 이용해 세션 정보 로드
  - login(), reset()에서 호출됨

## 추가 메모

- 추후에 로그인 정보를 반응형으로 활용하고 싶은 경우에는 AuthManager에 Publisher를 추가하고, 코디네이터에서 Subscribe하는 방식을 생각 중

## 체크 리스트

- [x] 공개되어서는 안되는 데이터가 커밋되지 않았음을 확인함
- [x] 테스트 코드를 작성함
- [x] CHANGELOG에 변경 내용을 기록함
- [x] 하위 호환에 문제가 없는지 확인함
