### PR TITLE
refactor: 코디네이터에서 뷰 컨트롤러에 대한 DI를 진행하지 않음

### DIFF
--- a/PicplzClient/PicplzClient/App/DIContainerProvider.swift
+++ b/PicplzClient/PicplzClient/App/DIContainerProvider.swift
@@ -43,6 +43,7 @@ final class DIContainerProvider {
         }
         
         // MARK: Presentaion
+        // MARK:              ...  View Models
         container.register(MainViewModelProtocol.self) { r in
             let viewModel = MainViewModel()
             viewModel.logoutUseCase = r.resolve(LogoutUseCase.self)
@@ -55,6 +56,19 @@ final class DIContainerProvider {
             return viewModel
         }
         container.register(OnboardingViewModelProtocol.self) { _ in OnboardingViewModel() }
+        
+        // MARK:              ...  View Controllers
+        container.register(OnboardingViewController.self) { r in
+            let vc = OnboardingViewController()
+            vc.viewModel = r.resolve(OnboardingViewModelProtocol.self)
+            return vc
+        }
+        container.register(MainViewController.self) { r in
+            let vc = MainViewController()
+            vc.viewModel = r.resolve(MainViewModelProtocol.self)
+            return vc
+        }
+        
         
         return container
     }

--- a/PicplzClient/PicplzClient/Presentation/Login/Coordinator/LoginCoordinator.swift
+++ b/PicplzClient/PicplzClient/Presentation/Login/Coordinator/LoginCoordinator.swift
@@ -30,12 +30,11 @@ final class LoginCoordinator: Coordinator {
     }
     
     func start() {
-        var viewModel = container.resolve(OnboardingViewModelProtocol.self)
-        viewModel?.delegate = self
-        let viewController = OnboardingViewController()
-        viewController.viewModel = viewModel
-        
-        navigationController.viewControllers = [viewController]
+        guard let rootViewController = container.resolve(OnboardingViewController.self) else {
+            preconditionFailure("viewController could not be resolved...")
+        }
+        rootViewController.viewModel.delegate = self
+        navigationController.viewControllers = [rootViewController]
         
         log.debug("LoginCoordinator started")
     }

--- a/PicplzClient/PicplzClient/Presentation/Main/Coordinator/MainCoordinator.swift
+++ b/PicplzClient/PicplzClient/Presentation/Main/Coordinator/MainCoordinator.swift
@@ -30,12 +30,11 @@ final class MainCoordinator: Coordinator {
     }
     
     func start() {
-        var viewModel = container.resolve(MainViewModelProtocol.self)
-        viewModel?.delegate = self
-        
-        let viewController = MainViewController()
-        viewController.viewModel = viewModel
-        navigationController.viewControllers = [viewController]
+        guard let rootViewController = container.resolve(MainViewController.self) else {
+            preconditionFailure("viewController could not be resolved...")
+        }
+        rootViewController.viewModel.delegate = self
+        navigationController.viewControllers = [rootViewController]
     }
 }
 


### PR DESCRIPTION
## 개요

- 관련 이슈: #8

## 변경점

- DIContainerProvider::makeContainer()에 뷰 컨트롤러도 등록
- 코디네이터에서 뷰 컨트롤러 resolve 후 viewModel의 delegate만 self로 할당하도록 설정

## 체크 리스트

- [x] 공개되어서는 안되는 데이터가 커밋되지 않았음을 확인함
- [ ] 테스트 코드를 작성함
- [ ] CHANGELOG에 변경 내용을 기록함
- [ ] 하위 호환에 문제가 없는지 확인함
