### PR TITLE
fix: 경력 없음 선택 시에도 경력 선택 페이지로 이동했던 문제

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 최조 회원 정보 등록 (SignUpCoordinator)
 - 네비게이션 바 커스텀 디자인 적용
 
+### Fixed
+- 경력 없음 선택 시에도 경력 선택 페이지로 이동했던 문제
+
 [unreleased]: https://github.com/Picplz/picplz-ios

--- a/PicplzClient/PicplzClient/Presentation/Login/ViewModel/SignUpPhotographerCareerTypePageViewModel.swift
+++ b/PicplzClient/PicplzClient/Presentation/Login/ViewModel/SignUpPhotographerCareerTypePageViewModel.swift
@@ -67,11 +67,18 @@ final class SignUpPhotographerCareerTypePageViewModel: SignUpPhotographerCareerT
     }
     
     func nextButtonDidTapped() {
-        if shouldShowPrompt && (havingCareer ?? false) { // 프롬프트 표시 중 + 경력 있음 -> 설정 뷰 표시
+        let havingCareer = self.havingCareer ?? false
+        
+        if shouldShowPrompt && havingCareer { // 프롬프트 표시 중 + 경력 있음 -> 설정 뷰 표시
             shouldShowPrompt = false
             nextButtonEnabled = false
         } else { // 다음 페이지 이동
-            delegate?.goToNextPage(current: currentPage, session: signUpSession)
+            var adjustedCurrentPage = self.currentPage
+            if !havingCareer {
+                adjustedCurrentPage += 1 // 경험 없음을 선택한 경우 다다음 페이지로 이동
+            }
+            
+            delegate?.goToNextPage(current: adjustedCurrentPage, session: signUpSession)
         }
     }
 }


### PR DESCRIPTION
## 개요

- 관련 이슈: #13 
- 

## 변경점

- SignUpPhotographerCareerTypePageViewModel에서 다음 버튼 핸들러의 로직 수정

## 체크 리스트

- [x] 공개되어서는 안되는 데이터가 커밋되지 않았음을 확인함
- [x] 테스트 코드를 작성함
- [x] CHANGELOG에 변경 내용을 기록함
- [x] 하위 호환에 문제가 없는지 확인함
